### PR TITLE
Fix for the typo in generating script and Cpp linking issue

### DIFF
--- a/umsg_gen/umsg_gen/core/inc/umsg.h
+++ b/umsg_gen/umsg_gen/core/inc/umsg.h
@@ -4,6 +4,11 @@
 
 #ifndef UMSG_UMSG_H
 #define UMSG_UMSG_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <umsg_types.h>
 
 typedef struct
@@ -27,5 +32,10 @@ umsg_sub_handle_t umsg_subscribe(umsg_msg_metadata_t* msg, uint16_t prescaler, u
 void umsg_publish(umsg_msg_metadata_t* msg, void* data, uint8_t ch_id);
 uint8_t umsg_receive(umsg_sub_handle_t queue, void* data, uint32_t timeout);
 uint8_t umsg_peek(umsg_msg_metadata_t* msg, void* data, uint32_t size);
+
+#ifdef __cplusplus
+}
+#endif
+
 
 #endif //UMSG_UMSG_H

--- a/umsg_gen/umsg_gen/core/inc/umsg_port.h
+++ b/umsg_gen/umsg_gen/core/inc/umsg_port.h
@@ -4,6 +4,9 @@
 
 #ifndef UMSG_UMSG_PORT_H
 #define UMSG_UMSG_PORT_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include <umsg.h>
 
@@ -11,5 +14,9 @@ void * umsg_port_malloc(uint32_t size);
 void * umsg_port_create(uint32_t size, uint8_t length);
 void umsg_port_send(umsg_sub_t* sub, void * data);
 uint8_t umsg_port_receive(umsg_sub_handle_t sub_handle, void * data, uint32_t timeout);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif //UMSG_UMSG_PORT_H

--- a/umsg_gen/umsg_gen/core/inc/umsg_types.h
+++ b/umsg_gen/umsg_gen/core/inc/umsg_types.h
@@ -4,10 +4,18 @@
 
 #ifndef UMSG_UMSG_TYPES_H
 #define UMSG_UMSG_TYPES_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>
 
 typedef void* umsg_sub_handle_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif //UMSG_UMSG_TYPES_H

--- a/umsg_gen/umsg_gen/templates/msg.h.j2
+++ b/umsg_gen/umsg_gen/templates/msg.h.j2
@@ -29,6 +29,11 @@ umsg_{{topic_dict.name}}_{{type.lower()}}_t
 {% endmacro %}
 // Generated with umsg_gen on {{ date }}
 #pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <umsg_types.h>
 
 // msg structure typedefs
@@ -66,4 +71,9 @@ uint8_t umsg_{{prefix}}_receive(umsg_sub_handle_t queue, umsg_{{prefix}}_t* data
 uint8_t umsg_{{prefix}}_peek(umsg_{{prefix}}_t* data);
 
 {% endfor %}
+
+#ifdef __cplusplus
+}
+#endif
+
 

--- a/umsg_gen/umsg_gen/umsg_gen.py
+++ b/umsg_gen/umsg_gen/umsg_gen.py
@@ -27,7 +27,7 @@ def main():
     cmake_template = env.get_template(name='CMakeLists.txt.j2')
 
     # find all topic json files
-    files = glob.glob(f'{msg_def_path}\*.json')
+    files = glob.glob(f'{msg_def_path}/*.json')
 
     # if files list is empty return error
     if not files:

--- a/umsg_lib/core/inc/umsg.h
+++ b/umsg_lib/core/inc/umsg.h
@@ -4,6 +4,11 @@
 
 #ifndef UMSG_UMSG_H
 #define UMSG_UMSG_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <umsg_types.h>
 
 typedef struct
@@ -27,5 +32,10 @@ umsg_sub_handle_t umsg_subscribe(umsg_msg_metadata_t* msg, uint16_t prescaler, u
 void umsg_publish(umsg_msg_metadata_t* msg, void* data, uint8_t ch_id);
 uint8_t umsg_receive(umsg_sub_handle_t queue, void* data, uint32_t timeout);
 uint8_t umsg_peek(umsg_msg_metadata_t* msg, void* data, uint32_t size);
+
+#ifdef __cplusplus
+}
+#endif
+
 
 #endif //UMSG_UMSG_H

--- a/umsg_lib/core/inc/umsg_port.h
+++ b/umsg_lib/core/inc/umsg_port.h
@@ -4,6 +4,9 @@
 
 #ifndef UMSG_UMSG_PORT_H
 #define UMSG_UMSG_PORT_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include <umsg.h>
 
@@ -11,5 +14,9 @@ void * umsg_port_malloc(uint32_t size);
 void * umsg_port_create(uint32_t size, uint8_t length);
 void umsg_port_send(umsg_sub_t* sub, void * data);
 uint8_t umsg_port_receive(umsg_sub_handle_t sub_handle, void * data, uint32_t timeout);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif //UMSG_UMSG_PORT_H

--- a/umsg_lib/core/inc/umsg_types.h
+++ b/umsg_lib/core/inc/umsg_types.h
@@ -4,10 +4,18 @@
 
 #ifndef UMSG_UMSG_TYPES_H
 #define UMSG_UMSG_TYPES_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>
 
 typedef void* umsg_sub_handle_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif //UMSG_UMSG_TYPES_H

--- a/umsg_lib/inc/umsg_battery.h
+++ b/umsg_lib/inc/umsg_battery.h
@@ -1,5 +1,10 @@
-// Generated with umsg_gen on 2022-09-19
+// Generated with umsg_gen on 2024-08-05
 #pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <umsg_types.h>
 
 // msg structure typedefs
@@ -24,4 +29,9 @@ void umsg_battery_state_publish(umsg_battery_state_t* data);
 void umsg_battery_state_publish_ch(umsg_battery_state_t* data, uint8_t channel);
 uint8_t umsg_battery_state_receive(umsg_sub_handle_t queue, umsg_battery_state_t* data, uint32_t timeout);
 uint8_t umsg_battery_state_peek(umsg_battery_state_t* data);
+
+
+#ifdef __cplusplus
+}
+#endif
 

--- a/umsg_lib/inc/umsg_control.h
+++ b/umsg_lib/inc/umsg_control.h
@@ -1,5 +1,10 @@
-// Generated with umsg_gen on 2022-09-19
+// Generated with umsg_gen on 2024-08-05
 #pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <umsg_types.h>
 
 // msg structure typedefs
@@ -17,4 +22,9 @@ void umsg_control_setpoints_publish(umsg_control_setpoints_t* data);
 void umsg_control_setpoints_publish_ch(umsg_control_setpoints_t* data, uint8_t channel);
 uint8_t umsg_control_setpoints_receive(umsg_sub_handle_t queue, umsg_control_setpoints_t* data, uint32_t timeout);
 uint8_t umsg_control_setpoints_peek(umsg_control_setpoints_t* data);
+
+
+#ifdef __cplusplus
+}
+#endif
 

--- a/umsg_lib/inc/umsg_example.h
+++ b/umsg_lib/inc/umsg_example.h
@@ -1,5 +1,10 @@
-// Generated with umsg_gen on 2022-09-19
+// Generated with umsg_gen on 2024-08-05
 #pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <umsg_types.h>
 
 // msg structure typedefs
@@ -38,4 +43,9 @@ void umsg_example_simple_msg_publish(umsg_example_simple_msg_t* data);
 void umsg_example_simple_msg_publish_ch(umsg_example_simple_msg_t* data, uint8_t channel);
 uint8_t umsg_example_simple_msg_receive(umsg_sub_handle_t queue, umsg_example_simple_msg_t* data, uint32_t timeout);
 uint8_t umsg_example_simple_msg_peek(umsg_example_simple_msg_t* data);
+
+
+#ifdef __cplusplus
+}
+#endif
 

--- a/umsg_lib/inc/umsg_sensors.h
+++ b/umsg_lib/inc/umsg_sensors.h
@@ -1,5 +1,10 @@
-// Generated with umsg_gen on 2022-09-19
+// Generated with umsg_gen on 2024-08-05
 #pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <umsg_types.h>
 
 // msg structure typedefs
@@ -30,4 +35,9 @@ void umsg_sensors_baro_publish(umsg_sensors_baro_t* data);
 void umsg_sensors_baro_publish_ch(umsg_sensors_baro_t* data, uint8_t channel);
 uint8_t umsg_sensors_baro_receive(umsg_sub_handle_t queue, umsg_sensors_baro_t* data, uint32_t timeout);
 uint8_t umsg_sensors_baro_peek(umsg_sensors_baro_t* data);
+
+
+#ifdef __cplusplus
+}
+#endif
 

--- a/umsg_lib/inc/umsg_test.h
+++ b/umsg_lib/inc/umsg_test.h
@@ -1,5 +1,10 @@
-// Generated with umsg_gen on 2022-09-19
+// Generated with umsg_gen on 2024-08-05
 #pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <umsg_types.h>
 
 // msg structure typedefs
@@ -115,4 +120,9 @@ void umsg_test_bitfield_publish(umsg_test_bitfield_t* data);
 void umsg_test_bitfield_publish_ch(umsg_test_bitfield_t* data, uint8_t channel);
 uint8_t umsg_test_bitfield_receive(umsg_sub_handle_t queue, umsg_test_bitfield_t* data, uint32_t timeout);
 uint8_t umsg_test_bitfield_peek(umsg_test_bitfield_t* data);
+
+
+#ifdef __cplusplus
+}
+#endif
 

--- a/umsg_lib/inc/umsg_unused.h
+++ b/umsg_lib/inc/umsg_unused.h
@@ -1,5 +1,10 @@
-// Generated with umsg_gen on 2022-09-19
+// Generated with umsg_gen on 2024-08-05
 #pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <umsg_types.h>
 
 // msg structure typedefs
@@ -29,4 +34,9 @@ void umsg_unused_unused_var_publish(umsg_unused_unused_var_t* data);
 void umsg_unused_unused_var_publish_ch(umsg_unused_unused_var_t* data, uint8_t channel);
 uint8_t umsg_unused_unused_var_receive(umsg_sub_handle_t queue, umsg_unused_unused_var_t* data, uint32_t timeout);
 uint8_t umsg_unused_unused_var_peek(umsg_unused_unused_var_t* data);
+
+
+#ifdef __cplusplus
+}
+#endif
 

--- a/umsg_lib/src/battery.c
+++ b/umsg_lib/src/battery.c
@@ -1,4 +1,4 @@
-// Generated with umsg_gen on 2022-09-19
+// Generated with umsg_gen on 2024-08-05
 #include <umsg.h>
 #include <umsg_battery.h>
 

--- a/umsg_lib/src/control.c
+++ b/umsg_lib/src/control.c
@@ -1,4 +1,4 @@
-// Generated with umsg_gen on 2022-09-19
+// Generated with umsg_gen on 2024-08-05
 #include <umsg.h>
 #include <umsg_control.h>
 

--- a/umsg_lib/src/example.c
+++ b/umsg_lib/src/example.c
@@ -1,4 +1,4 @@
-// Generated with umsg_gen on 2022-09-19
+// Generated with umsg_gen on 2024-08-05
 #include <umsg.h>
 #include <umsg_example.h>
 

--- a/umsg_lib/src/sensors.c
+++ b/umsg_lib/src/sensors.c
@@ -1,4 +1,4 @@
-// Generated with umsg_gen on 2022-09-19
+// Generated with umsg_gen on 2024-08-05
 #include <umsg.h>
 #include <umsg_sensors.h>
 

--- a/umsg_lib/src/test.c
+++ b/umsg_lib/src/test.c
@@ -1,4 +1,4 @@
-// Generated with umsg_gen on 2022-09-19
+// Generated with umsg_gen on 2024-08-05
 #include <umsg.h>
 #include <umsg_test.h>
 

--- a/umsg_lib/src/unused.c
+++ b/umsg_lib/src/unused.c
@@ -1,4 +1,4 @@
-// Generated with umsg_gen on 2022-09-19
+// Generated with umsg_gen on 2024-08-05
 #include <umsg.h>
 #include <umsg_unused.h>
 


### PR DESCRIPTION
As stated in the issue #5 there is a problem with generating the library headers on linux, this issue is caused by a typo, this pull request resolves #5. Issue #6 is solved by adding cpp extern C directive. This resolves #6.